### PR TITLE
Dllexport API functions on Windows

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,9 @@ thread_dep = dependency('threads')
 cc = meson.get_compiler('c')
 dl_dep = cc.find_library('dl', required: false)
 
+if host_machine.system() == 'windows'
+  add_project_arguments('-DSQLITE_API=__declspec(dllexport)', language: 'c')
+endif
 
 sqinc = include_directories('.')
 sqlib = library('sqlite', 'sqlite3.c', include_directories: sqinc,


### PR DESCRIPTION
Defining SQLITE_API makes sure API functions are exported from
sqlite.dll and that import library gets created.