### PR TITLE
Fix deprecation warning when using sqlite.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,8 @@
-project('sqlite', 'c', version : '3320300', license : 'pd')
-
+project('sqlite',
+        'c',
+        license : 'pd',
+        meson_version : '>=0.46',
+        version : '3320300')
 
 thread_dep = dependency('threads')
 
@@ -26,7 +29,7 @@ sqlite_dep = declare_dependency(link_with : sqlib,
     include_directories : sqinc)
 
 pkg = import('pkgconfig')
-pkg.generate(name: 'sqlite3',
+pkg.generate(sqlib,
+             name: 'sqlite3',
              description: 'An embedded SQL database engine',
-             version: meson.project_version(),
-             libraries: sqlib)
+             version: meson.project_version())

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -6,4 +6,4 @@ source_filename = sqlite-amalgamation-3320300.zip
 source_hash = e9cec01d4519e2d49b3810615237325263fe1feaceae390ee12b4a29bd73dbe2
 
 [provide]
-sqlite3_dep = sqlite_dep
+sqlite3 = sqlite_dep


### PR DESCRIPTION
See https://mesonbuild.com/Release-notes-for-0-49-0.html#deprecation-warning-in-pkgconfig-generator